### PR TITLE
Update example pod to use dci_openshift_app_ns variable or default

### DIFF
--- a/samples/basic_example/hooks/install.yml
+++ b/samples/basic_example/hooks/install.yml
@@ -15,7 +15,7 @@
       metadata:
         app: httpd
         name: webserver
-        namespace: myns
+        namespace: "{{ dci_openshift_app_ns | default('myns') }}"
       spec:
         containers:
           - name: webserver


### PR DESCRIPTION
A minor update to have the simple pod use the same namespace name as the rest of the example. 