### PR TITLE
Switch dnf packages from latest to present

### DIFF
--- a/roles/cnf-cert/tasks/pre-run.yml
+++ b/roles/cnf-cert/tasks/pre-run.yml
@@ -6,7 +6,7 @@
     name:
         - go-toolset
         - make
-    state: latest
+    state: present
 
 - name: Install ginkgo package
   shell: |


### PR DESCRIPTION
Doc: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dnf_module.html

Using the `latest` tag causes the Ansible to go out and look through the mirrors for the latest version every time.  In my opinion we should only have to install it once and avoid any potential mirror problems that pop up intermittently.

In the future, exact version numbers can be added to the `go-toolset` and `make` modules to specify which to install.