### PR TITLE
doc/nit: wrong block code on the ocp agent app

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ There are two configuration files for `dci-openshift-app-agent`:
 
     This file should be edited once:
 
-    ```Shell
-    #!/usr/bin/env bash
-    DCI_CS_URL="https://api.distributed-ci.io/"
-    DCI_CLIENT_ID=remoteci/<remoteci_id>
-    DCI_API_SECRET=<remoteci_api_secret>
-    export DCI_CLIENT_ID
-    export DCI_API_SECRET
-    export DCI_CS_URL
-    ```
+```ShellSession
+#!/usr/bin/env bash
+DCI_CS_URL="https://api.distributed-ci.io/"
+DCI_CLIENT_ID=remoteci/<remoteci_id>
+DCI_API_SECRET=<remoteci_api_secret>
+export DCI_CLIENT_ID
+export DCI_API_SECRET
+export DCI_CS_URL
+```
 
     > NOTE: The initial copy of `dcirc.sh` is shipped as `/etc/dci-openshift-app-agent/dcirc.sh.dist`. You can copy this to `/etc/dci-openshift-app-agent/dcirc.sh` to get started, then replace inline some values with your own credentials.
 


### PR DESCRIPTION
Fixing wrong code block from https://docs.distributed-ci.io/dci-openshift-app-agent/:

![Screenshot from 2022-11-22 18-15-31](https://user-images.githubusercontent.com/3216894/203422603-46685277-67b9-4900-bb29-09e8906d2858.png)
